### PR TITLE
use aws_accountid super property instead of distinctid

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ func main() {
 
 func heartbeat() {
 	for _ = range time.Tick(1 * time.Hour) {
-		message := fmt.Sprintf(`{"event": "kernel-heartbeat", "properties": {"distinct_id": %q, "token": %q}}`, os.Getenv("AWS_ACCOUNTID"), os.Getenv("MIXPANEL_TOKEN"))
+		message := fmt.Sprintf(`{"event": "kernel-heartbeat", "properties": {"aws_accountid": %q, "token": %q}}`, os.Getenv("AWS_ACCOUNTID"), os.Getenv("MIXPANEL_TOKEN"))
 		encMessage := b64.StdEncoding.EncodeToString([]byte(message))
 		_, err := http.Get(fmt.Sprintf("http://api.mixpanel.com/track/?data=%s", encMessage))
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ func main() {
 
 func heartbeat() {
 	for _ = range time.Tick(1 * time.Hour) {
-		message := fmt.Sprintf(`{"event": "kernel-heartbeat", "properties": {"aws_accountid": %q, "token": %q}}`, os.Getenv("AWS_ACCOUNTID"), os.Getenv("MIXPANEL_TOKEN"))
+		message := fmt.Sprintf(`{"event": "kernel-heartbeat", "properties": {"aws_accountid": %[1], "distinct_id": %[1], "token": %[2]}}`, os.Getenv("AWS_ACCOUNTID"), os.Getenv("MIXPANEL_TOKEN"))
 		encMessage := b64.StdEncoding.EncodeToString([]byte(message))
 		_, err := http.Get(fmt.Sprintf("http://api.mixpanel.com/track/?data=%s", encMessage))
 		if err != nil {

--- a/views/layout.tmpl
+++ b/views/layout.tmpl
@@ -78,7 +78,7 @@ mixpanel.init("43fb68427548c5e99978a598a9b14e55");</script><!-- end Mixpanel -->
 			});
 
 			// Track clicks in mixpanel
-			mixpanel.identify($('meta[name=accountid]').attr('content'));
+			mixpanel.register({'aws_accountid': $('meta[name=accountid]').attr('content')});
 			$('.trackable').click(function() {
 				mixpanel.track($(this).attr('id') + '-click');
 			});

--- a/views/layout.tmpl
+++ b/views/layout.tmpl
@@ -79,6 +79,7 @@ mixpanel.init("43fb68427548c5e99978a598a9b14e55");</script><!-- end Mixpanel -->
 
 			// Track clicks in mixpanel
 			mixpanel.register({'aws_accountid': $('meta[name=accountid]').attr('content')});
+			mixpanel.identify($('meta[name=accountid]').attr('content'));
 			$('.trackable').click(function() {
 				mixpanel.track($(this).attr('id') + '-click');
 			});


### PR DESCRIPTION
I learned from the Mixpanel guy that the events tracking and people tracking are two separate offerings that don't mix (pun intended). So instead of using `mixpanel.identify` to set the AWS account id we're using `mixpanel.register` to set an aws_accountid "super property".