### PR TITLE
POC: POST a release for a manually pushed image

### DIFF
--- a/controllers/releases.go
+++ b/controllers/releases.go
@@ -1,0 +1,69 @@
+package controllers
+
+import (
+  "fmt"
+  "net/http"
+
+  "github.com/convox/kernel/Godeps/_workspace/src/github.com/ddollar/logger"
+  "github.com/convox/kernel/Godeps/_workspace/src/github.com/gorilla/mux"
+
+  "github.com/convox/kernel/helpers"
+  "github.com/convox/kernel/models"
+)
+
+func ReleaseCreate(rw http.ResponseWriter, r *http.Request) {
+  // app name, docker image tag and id
+  log := releasesLogger("create").Start()
+
+  vars := mux.Vars(r)
+  name := vars["app"]
+
+  ports := GetForm(r, "ports")
+  tag   := GetForm(r, "tag")
+
+  fmt.Printf("%+v\n", r.URL.Query())
+
+  app, err := models.GetApp(name)
+
+  if err != nil {
+    helpers.Error(log, err)
+    RenderError(rw, err)
+    return
+  }
+
+  release, err := app.ForkRelease()
+
+  if err != nil {
+    helpers.Error(log, err)
+    RenderError(rw, err)
+    return
+  }
+
+  build := models.NewBuild(app.Name)
+  build.Id = tag
+  build.Release = release.Id
+  build.Status = "complete"
+
+  release.Build = build.Id
+  release.Manifest = fmt.Sprintf(`unnamed:
+  ports:
+    - %s
+`, ports)
+
+  err = build.Save()
+  err = release.Save()
+  err = release.Promote()
+
+  if err != nil {
+    RenderError(rw, err)
+    return
+  }
+
+  log.Success("step=release.create app=%q", app.Name)
+
+  RenderText(rw, "ok")
+}
+
+func releasesLogger(at string) *logger.Logger {
+  return logger.New("ns=kernel cn=releases").At(at)
+}

--- a/models/release.go
+++ b/models/release.go
@@ -195,8 +195,14 @@ func (r *Release) Promote() error {
 	}
 
 	for _, ps := range pss {
+		image := fmt.Sprintf("%s/%s-%s:%s", os.Getenv("REGISTRY_HOST"), r.App, ps.Name, r.Build)
+
+		if ps.Name == "unnamed" {
+			image = fmt.Sprintf("%s/%s:%s", os.Getenv("REGISTRY_HOST"), r.App, r.Build)
+		}
+
 		app.Parameters[fmt.Sprintf("%sCommand", upperName(ps.Name))] = ps.Command
-		app.Parameters[fmt.Sprintf("%sImage", upperName(ps.Name))] = fmt.Sprintf("%s/%s-%s:%s", os.Getenv("REGISTRY_HOST"), r.App, ps.Name, r.Build)
+		app.Parameters[fmt.Sprintf("%sImage", upperName(ps.Name))] = image
 		app.Parameters[fmt.Sprintf("%sScale", upperName(ps.Name))] = strconv.Itoa(ps.Count)
 	}
 

--- a/web.go
+++ b/web.go
@@ -111,6 +111,7 @@ func startWeb() {
 	router.HandleFunc("/apps/{app}/processes/{process}/resources", controllers.ProcessResources).Methods("GET")
 	router.HandleFunc("/apps/{app}/promote", controllers.AppPromote).Methods("POST")
 	router.HandleFunc("/apps/{app}/releases", controllers.AppReleases).Methods("GET")
+	router.HandleFunc("/apps/{app}/releases", controllers.ReleaseCreate).Methods("POST")
 	router.HandleFunc("/apps/{app}/resources", controllers.AppResources).Methods("GET")
 	router.HandleFunc("/apps/{app}/services", controllers.ServiceLink).Methods("POST")
 	router.HandleFunc("/apps/{app}/services/{name}", controllers.ServiceUnlink).Methods("DELETE")


### PR DESCRIPTION
Proof of concept. A simpler and useful workflow is to push a pre-built image then cut a release from that. For example:

```
$ docker pull httpd
$ docker tag httpd $REGISTRYHOST/httpd:$TAG
$ docker push $REGISTRYHOST/httpd:$TAG

$ curl -vik -u u:$REGISTRY_PASSWORD -X POST -d "tag=$TAG&ports=$PORTS" https://$CONSOLE_HOST/apps/httpd/releases
```

One major difference is that we do not have a docker-compose.yml manifest in this case, so the convention of using ps.Name in the image url does not work.
