### PR TITLE
prod parity w.r.t service ports and env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,14 +19,15 @@ web:
     - SUBNETS
     - VPC
   ports:
-    - 5000:3000
-    - 4443:4443
+    - 80:3000
+    - 443:4443
   volumes:
     - ./:/go/src/github.com/convox/kernel
     - /var/run/docker.sock:/var/run/docker.sock
 registry:
   environment:
     - SETTINGS_FLAVOR=local
+    - PASSWORD
   image: convox/registry
   ports:
-    - 5100:443
+    - 5000:443


### PR DESCRIPTION
Why don't we run the kernel in dev on port 80, 443 and the registry on port 5000, just like prod?

This helps `convox login` work without special changes for dev.

There's also something subtle about REGISTRY_PASSWORD and PASSWORD in dev vs production.