### PR TITLE
Ecs tasks services

### DIFF
--- a/models/app.go
+++ b/models/app.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
-	"strings"
 	"time"
 
 	"github.com/convox/kernel/helpers"
@@ -262,9 +261,7 @@ func (a *App) LatestRelease() (*Release, error) {
 }
 
 func (a *App) TaskDefinitionFamily() string {
-	resources := a.Resources()
-	name := strings.Split(resources["TaskDefinition"].Id, "/")[1]
-	return strings.Split(name, ":")[0]
+	return a.Name
 }
 
 func (a *App) WatchForCompletion(change *Change, original Events) {

--- a/models/process.go
+++ b/models/process.go
@@ -37,6 +37,7 @@ type ProcessRunOptions struct {
 func ListProcesses(app string) (Processes, error) {
 	req := &ecs.ListTasksInput{
 		Cluster: aws.String(os.Getenv("CLUSTER")),
+		Family: aws.String(app),
 	}
 
 	res, err := ECS().ListTasks(req)
@@ -55,14 +56,7 @@ func ListProcesses(app string) (Processes, error) {
 	pss := Processes{}
 
 	for _, task := range tres.Tasks {
-		parts := strings.Split(*task.TaskDefinitionARN, "/")
-		fam := parts[1]
-
-		if !strings.HasPrefix(fam, fmt.Sprintf("%s-", app)) {
-			continue
-		}
-
-		parts = strings.Split(*task.TaskARN, "-")
+		parts := strings.Split(*task.TaskARN, "-")
 		id := parts[len(parts)-1]
 
 		tres, err := ECS().DescribeTaskDefinition(&ecs.DescribeTaskDefinitionInput{


### PR DESCRIPTION
Fix up handling of ECS Tasks and Services.

Task Definition Family always will be the app name. Get all tasks for Family for `ps` output.

Get all service ARNs that match the app name / family for `debug` output.



