### PR TITLE
create swap via userdata

### DIFF
--- a/dist/kernel.json
+++ b/dist/kernel.json
@@ -427,7 +427,7 @@
         "UserData": { "Fn::Base64": 
           { "Fn::Join": [ "\n", [
             "#!/bin/bash",
-            "dd if=/dev/zero of=/swapfile bs=10M count=512 && chmod 0600 /swapfile && mkswap /swapfile && swapon /swapfile",
+            "fallocate -l 5G /swapfile && chmod 0600 /swapfile && mkswap /swapfile && swapon /swapfile",
             "yum -y update",
             { "Fn::Join": [ "", [ "echo ECS_CLUSTER=", { "Ref": "Cluster" }, " >> /etc/ecs/ecs.config" ] ] },
             "echo ECS_ENGINE_AUTH_TYPE=docker >> /etc/ecs/ecs.config",

--- a/dist/kernel.json
+++ b/dist/kernel.json
@@ -427,6 +427,7 @@
         "UserData": { "Fn::Base64": 
           { "Fn::Join": [ "\n", [
             "#!/bin/bash",
+            "dd if=/dev/zero of=/swapfile bs=10M count=512 && chmod 0600 /swapfile && mkswap /swapfile && swapon /swapfile",
             "yum -y update",
             { "Fn::Join": [ "", [ "echo ECS_CLUSTER=", { "Ref": "Cluster" }, " >> /etc/ecs/ecs.config" ] ] },
             "echo ECS_ENGINE_AUTH_TYPE=docker >> /etc/ecs/ecs.config",

--- a/dist/kernel.json
+++ b/dist/kernel.json
@@ -443,7 +443,7 @@
             "docker start ecs-agent",
             "mkdir -p /etc/convox",
             { "Fn::Join": [ "", [ "echo \"", { "Ref": "AWS::Region" }, "\" > /etc/convox/region" ] ] },
-            "curl -s http://convox.s3.amazonaws.com/agent/0.2/convox.conf > /etc/init/convox.conf",
+            "curl -s http://convox.s3.amazonaws.com/agent/0.3/convox.conf > /etc/init/convox.conf",
             "start convox"
           ] ] } 
         }


### PR DESCRIPTION
One of the simplest strategies to initialize swap space. Some considerations:

* It takes ~90s to initialize the 5GB file on boot
* Should 5GB be parameterized? 0GB could make sense for some, 10GB for others.
* Does the initialization eat up EBS credits?
* If an instance has an ephemeral drive, it's better to put swap on that. How to detect?
* Currently ECS don't offer container swap configuration. Another patch is needed to actually use this with ECS 