### PR TITLE
formation: generate AZ output dynamically

### DIFF
--- a/cmd/formation/handler/ec2.go
+++ b/cmd/formation/handler/ec2.go
@@ -3,6 +3,8 @@ package handler
 import (
 	"fmt"
 	"regexp"
+	"strings"
+	"strconv"
 
 	"github.com/convox/kernel/Godeps/_workspace/src/github.com/awslabs/aws-sdk-go/aws"
 	"github.com/convox/kernel/Godeps/_workspace/src/github.com/awslabs/aws-sdk-go/service/ec2"
@@ -29,7 +31,7 @@ func HandleEC2AvailabilityZones(req Request) (string, map[string]string, error) 
 	return "", nil, fmt.Errorf("unknown RequestType: %s", req.RequestType)
 }
 
-var regexMatchAvailabilityZones = regexp.MustCompile(`following availability zones: ([^,.]+), ([^,.]+), ([^,.]+)`)
+var regexMatchAvailabilityZones = regexp.MustCompile(`following availability zones: ([^.]+)`)
 
 func EC2AvailabilityZonesCreate(req Request) (string, map[string]string, error) {
 	_, err := EC2(req).CreateSubnet(&ec2.CreateSubnetInput{
@@ -39,19 +41,18 @@ func EC2AvailabilityZonesCreate(req Request) (string, map[string]string, error) 
 	})
 
 	matches := regexMatchAvailabilityZones.FindStringSubmatch(err.Error())
+	matches = strings.Split(strings.Replace(matches[1], " ", "", -1), ",")
 
-	if len(matches) != 4 {
+	if len(matches) < 1 {
 		return "", nil, fmt.Errorf("could not discover availability zones")
 	}
 
-	outputs := map[string]string{
-		"AvailabilityZone0": matches[1],
-		"AvailabilityZone1": matches[2],
-		"AvailabilityZone2": matches[3],
+	outputs := make(map[string]string)
+	for i, az := range matches {
+		outputs["AvailabilityZone" + strconv.Itoa(i)] = az
 	}
 
-	physical := fmt.Sprintf("%s,%s,%s", matches[1], matches[2], matches[3])
-
+	physical := strings.Join(matches, ",")
 	return physical, outputs, nil
 }
 


### PR DESCRIPTION
Quite a few regions have only 2 AZs, while some have more than 3: https://aws.amazon.com/about-aws/global-infrastructure/

The intent of this PR is to dynamically generate the output to list all AZs that allow subnet creation.

This should be backwards compatible for `us-east-1` and pave the way for multi-region support per convox/cli/issues/47