### PR TITLE
lag deleting an app

### DIFF
--- a/controllers/apps.go
+++ b/controllers/apps.go
@@ -110,7 +110,13 @@ func AppCreate(rw http.ResponseWriter, r *http.Request) {
 	err := app.Create()
 
 	if awsError(err) == "AlreadyExistsException" {
-		err = fmt.Errorf("There is already an app named %s", name)
+		app, err := models.GetApp(name)
+		if err != nil {
+			helpers.Error(log, err)
+			RenderError(rw, err)
+			return
+		}
+		err = fmt.Errorf("There is already an app named %s (%s)", name, app.Status)
 		helpers.Error(log, err)
 		RenderError(rw, err)
 		return


### PR DESCRIPTION
In my cluster there's a ~3min lag deleting an app.

https://github.com/convox/kernel/blob/master/models/app.go#L169

During that time Cloudformation is destroying the stack but the CLI has led me to believe it's all done:

```shell
$ convox apps delete test-convox
Deleting test-convox... OK

$ convox apps create
Creating app test-convox... ERROR: There is already an app named test-convox
```

This is only an issue if you're reusing the app name straight away, which is conceivable especially when testing or new.

Users probably don't care to watch the actual teardown of an app, so waiting for output is probably not a thing (ala cluster uninstaller).

This could be mitigated somewhat by changing the confirmation message to something like `DELETE QUEUED` and then on create checking to see the state of the existing app `ERROR: There is already an app named test-convox (currently deleting)` or so
