### PR TITLE
Untruncate logs

### DIFF
--- a/models/build.go
+++ b/models/build.go
@@ -408,8 +408,8 @@ func buildFromItem(item map[string]*dynamodb.AttributeValue) *Build {
 	key := "logs1"
 
 	for {
-		if _, ok := item[key]; ok {
-			build.Logs += coalesce(item[key], "")
+		if logs := coalesce(item[key], ""); logs != "" {
+			build.Logs += logs
 			i += 1
 			key = fmt.Sprintf("logs%d", i)
 		} else {

--- a/models/build.go
+++ b/models/build.go
@@ -132,6 +132,7 @@ func (b *Build) Save() error {
 				remainder = remainder[logMax:]
 			} else {
 				logs = remainder
+				remainder = ""
 			}
 
 			if counter == 0 {

--- a/models/build.go
+++ b/models/build.go
@@ -393,7 +393,7 @@ func buildFromItem(item map[string]*dynamodb.AttributeValue) *Build {
 	started, _ := time.Parse(SortableTime, coalesce(item["created"], ""))
 	ended, _ := time.Parse(SortableTime, coalesce(item["ended"], ""))
 
-	return &Build{
+	build := &Build{
 		Id:       coalesce(item["id"], ""),
 		App:      coalesce(item["app"], ""),
 		Logs:     coalesce(item["logs"], ""),
@@ -403,4 +403,19 @@ func buildFromItem(item map[string]*dynamodb.AttributeValue) *Build {
 		Started:  started,
 		Ended:    ended,
 	}
+
+	i := 1
+	key := "logs1"
+
+	for {
+		if _, ok := item[key]; ok {
+			build.Logs += coalesce(item[key], "")
+			i += 1
+			key = fmt.Sprintf("logs%d", i)
+		} else {
+			break
+		}
+	}
+
+	return build
 }

--- a/models/build.go
+++ b/models/build.go
@@ -138,7 +138,7 @@ func (b *Build) Save() error {
 			if counter == 0 {
 				key = "logs"
 			} else {
-				key = fmt.Sprintf("logs%s", counter)
+				key = fmt.Sprintf("logs%d", counter)
 			}
 
 			(*req.Item)[key] = &dynamodb.AttributeValue{S: aws.String(logs)}

--- a/models/build.go
+++ b/models/build.go
@@ -121,13 +121,29 @@ func (b *Build) Save() error {
 	if b.Logs != "" {
 		logMax := 1024 * 395 // Dynamo attribute can be 400k max
 
-		logs := b.Logs
+		var logs string
+		var key string
+		remainder := b.Logs
+		counter := 0
 
-		if len(logs) > logMax {
-			logs = logs[0:logMax]
+		for len(remainder) > 0 {
+			if len(remainder) > logMax {
+				logs = remainder[0:logMax]
+				remainder = remainder[logMax:]
+			} else {
+				logs = remainder
+			}
+
+			if counter == 0 {
+				key = "logs"
+			} else {
+				key = fmt.Sprintf("logs%s", counter)
+			}
+
+			(*req.Item)[key] = &dynamodb.AttributeValue{S: aws.String(logs)}
+
+			counter += 1
 		}
-
-		(*req.Item)["logs"] = &dynamodb.AttributeValue{S: aws.String(logs)}
 	}
 
 	if b.Manifest != "" {


### PR DESCRIPTION
DynamoDB has a 400kb limit for object size. When the build logs are larger than 400kb, sequentially numbered keys are created to handle the extra data (ex: logs, logs1, logs2, . . . )

When the build info is fetched, these extended log objects are concatenated onto the Log attribute of the Build struct.