### PR TITLE
Intialize image without impacting other docker containers

### DIFF
--- a/dist/kernel.json
+++ b/dist/kernel.json
@@ -443,12 +443,10 @@
               { "Fn::Join": [ "", [ "echo 'OPTIONS=\"--insecure-registry=", { "Fn::Join": [ ":", [ { "Fn::GetAtt": [ "Balancer", "DNSName" ] }, "5000" ] ] }, " --host=unix:///var/run/docker.sock --host=0.0.0.0:2376\"' >> /etc/sysconfig/docker" ] ] },
               "echo 'OPTIONS=\"--host=unix:///var/run/docker.sock  --host=0.0.0.0:2376\"' >> /etc/sysconfig/docker"
             ] },
-            "service docker restart",
-            "docker start ecs-agent",
             "mkdir -p /etc/convox",
             { "Fn::Join": [ "", [ "echo \"", { "Ref": "AWS::Region" }, "\" > /etc/convox/region" ] ] },
             "curl -s http://convox.s3.amazonaws.com/agent/0.3/convox.conf > /etc/init/convox.conf",
-            "start convox"
+            "reboot"
           ] ] }
         }
       }


### PR DESCRIPTION
When the user chooses to run a different AMI (see https://github.com/convox/kernel/pull/132), the AMI can provide other docker containers. 

To prevent impacting them, we reboot after initializing to avoid restarting the docker daemon and guarantee that all the other docker containers beyond Convox control are launched as expected.