### PR TITLE
get service metrics

### DIFF
--- a/controllers/processes.go
+++ b/controllers/processes.go
@@ -206,7 +206,45 @@ func ProcessTop(rw http.ResponseWriter, r *http.Request) {
 
 	vars := mux.Vars(r)
 	app := vars["app"]
-	process := vars["process"]
+	id := vars["id"]
+
+	_, err := models.GetApp(app)
+
+	if awsError(err) == "ValidationError" {
+		RenderNotFound(rw, fmt.Sprintf("no such app: %s", app))
+		return
+	}
+
+	ps, err := models.GetProcessById(app, id)
+
+	if err != nil {
+		helpers.Error(log, err)
+		RenderError(rw, err)
+		return
+	}
+
+	if ps == nil {
+		RenderNotFound(rw, fmt.Sprintf("no such process: %s", id))
+		return
+	}
+
+	info, err := ps.Top()
+
+	if err != nil {
+		helpers.Error(log, err)
+		RenderError(rw, err)
+		return
+	}
+
+	RenderJson(rw, info)
+}
+
+func ProcessTypeTop(rw http.ResponseWriter, r *http.Request) {
+	log := processesLogger("info").Start()
+
+	vars := mux.Vars(r)
+	app := vars["app"]
+	process := vars["process_type"]
 
 	_, err := models.GetApp(app)
 

--- a/web.go
+++ b/web.go
@@ -109,7 +109,7 @@ func startWeb() {
 	router.HandleFunc("/apps/{app}/processes", controllers.ProcessList).Methods("GET")
 	router.HandleFunc("/apps/{app}/processes/{process}", controllers.ProcessShow).Methods("GET")
 	router.HandleFunc("/apps/{app}/processes/{id}", controllers.ProcessStop).Methods("DELETE")
-	router.HandleFunc("/apps/{app}/processes/{process}/top", controllers.ProcessTop).Methods("GET")
+	router.HandleFunc("/apps/{app}/processes/{id}/top", controllers.ProcessTop).Methods("GET")
 	router.HandleFunc("/apps/{app}/process_types/{process_type}/top", controllers.ProcessTypeTop).Methods("GET")
 	router.HandleFunc("/apps/{app}/processes/{process}/logs", controllers.ProcessLogs).Methods("GET")
 	router.Handle("/apps/{app}/processes/{process}/run", websocket.Handler(controllers.ProcessRunAttached)).Methods("GET")

--- a/web.go
+++ b/web.go
@@ -109,7 +109,7 @@ func startWeb() {
 	router.HandleFunc("/apps/{app}/processes", controllers.ProcessList).Methods("GET")
 	router.HandleFunc("/apps/{app}/processes/{process}", controllers.ProcessShow).Methods("GET")
 	router.HandleFunc("/apps/{app}/processes/{id}", controllers.ProcessStop).Methods("DELETE")
-	router.HandleFunc("/apps/{app}/processes/{id}/top", controllers.ProcessTop).Methods("GET")
+	router.HandleFunc("/apps/{app}/processes/{process}/top", controllers.ProcessTop).Methods("GET")
 	router.HandleFunc("/apps/{app}/processes/{process}/logs", controllers.ProcessLogs).Methods("GET")
 	router.Handle("/apps/{app}/processes/{process}/run", websocket.Handler(controllers.ProcessRunAttached)).Methods("GET")
 	router.HandleFunc("/apps/{app}/processes/{process}/run", controllers.ProcessRun).Methods("POST")

--- a/web.go
+++ b/web.go
@@ -110,6 +110,7 @@ func startWeb() {
 	router.HandleFunc("/apps/{app}/processes/{process}", controllers.ProcessShow).Methods("GET")
 	router.HandleFunc("/apps/{app}/processes/{id}", controllers.ProcessStop).Methods("DELETE")
 	router.HandleFunc("/apps/{app}/processes/{process}/top", controllers.ProcessTop).Methods("GET")
+	router.HandleFunc("/apps/{app}/process_types/{process_type}/top", controllers.ProcessTypeTop).Methods("GET")
 	router.HandleFunc("/apps/{app}/processes/{process}/logs", controllers.ProcessLogs).Methods("GET")
 	router.Handle("/apps/{app}/processes/{process}/run", websocket.Handler(controllers.ProcessRunAttached)).Methods("GET")
 	router.HandleFunc("/apps/{app}/processes/{process}/run", controllers.ProcessRun).Methods("POST")


### PR DESCRIPTION
This PR adds the ability to fetch Service metrics from CloudWatch. Unfortunately, ECS doesn't report container-level metrics as I originally thought. Instead, it reports Service metrics which are an amalgamation of all of the Tasks of a certain type. Hopefully we can figure out a way to custom instrument container metrics in the future to get more granularity.

This uses 2 AWS API calls.
- ListMetrics to get a list of the service metrics available
- GetMetricsStatistics to fetch the actual datapoints

Supports https://github.com/convox/cli/pull/117