### PR TITLE
Don't restart ecs-agent during initialization

### DIFF
--- a/dist/kernel.json
+++ b/dist/kernel.json
@@ -466,7 +466,6 @@
               "echo 'OPTIONS=\"--host=unix:///var/run/docker.sock  --host=0.0.0.0:2376\"' >> /etc/sysconfig/docker"
             ] },
             "service docker restart",
-            "docker start ecs-agent",
             "mkdir -p /etc/convox",
             { "Fn::Join": [ "", [ "echo \"", { "Ref": "AWS::Region" }, "\" > /etc/convox/region" ] ] },
             "curl -s http://convox.s3.amazonaws.com/agent/0.3/convox.conf > /etc/init/convox.conf",


### PR DESCRIPTION
`ecs-agent` will restart by itself later on because:

1. The UserData (cloud-init) is run in system-v initialization
   (/etc/rc.d/rc?.d/S98cloud-final) through the rc Upstart task.

2. ecs is expliticly initialized after the rc task is done, see
   https://github.com/aws/amazon-ecs-init/blob/master/packaging/amazon-linux-ami/ecs.conf#L17

In fact, `docker start ecs-agent` will simply fail because the UserData
initialization is [*only run during the first boot cycle when an instance is
launched*](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/user-data.html) 
and per (2) above the `ecs-agent` container can't exist in a clean AMI by the
time the UserData script is executed.