### PR TITLE
only need STDOUT of convox/app

### DIFF
--- a/models/app.go
+++ b/models/app.go
@@ -206,7 +206,7 @@ func (a *App) UpdateParams(changes map[string]string) error {
 }
 
 func (a *App) Formation() (string, error) {
-	data, err := exec.Command("docker", "run", fmt.Sprintf("convox/app:%s", os.Getenv("RELEASE")), "-mode", "staging").CombinedOutput()
+	data, err := exec.Command("docker", "run", fmt.Sprintf("convox/app:%s", os.Getenv("RELEASE")), "-mode", "staging").Output()
 
 	if err != nil {
 		return "", err

--- a/models/service.go
+++ b/models/service.go
@@ -192,7 +192,7 @@ func (s *Service) Create() error {
 }
 
 func (s *Service) Formation() (string, error) {
-	data, err := exec.Command("docker", "run", fmt.Sprintf("convox/service:%s", os.Getenv("RELEASE")), s.Type).CombinedOutput()
+	data, err := exec.Command("docker", "run", fmt.Sprintf("convox/service:%s", os.Getenv("RELEASE")), s.Type).Output()
 
 	if err != nil {
 		return "", err


### PR DESCRIPTION
This should fix the JSON format error from STDERR output on downloading images.

However, we'll lose STDERR output.