### PR TITLE
Parameterize container names for app, build, and service

### DIFF
--- a/bin/web
+++ b/bin/web
@@ -6,9 +6,9 @@ pull_image() {
   docker pull $image >/dev/null 2>&1 &
 }
 
-pull_image convox/app:$RELEASE
-pull_image convox/build:$RELEASE
-pull_image convox/service:$RELEASE
+pull_image $DOCKER_IMAGE_APP
+pull_image $DOCKER_IMAGE_BUILD
+pull_image $DOCKER_IMAGE_SERVICE
 
 ./bin/gen-cert
 haproxy -f /etc/haproxy/haproxy.cfg &

--- a/dist/kernel.json
+++ b/dist/kernel.json
@@ -3,6 +3,9 @@
   "Conditions": {
     "BlankAmi": { "Fn::Equals": [ { "Ref": "Ami" }, "" ] },
     "BlankCertificate": { "Fn::Equals": [ { "Ref": "Certificate" }, "" ] },
+    "BlankDockerImageApp": { "Fn::Equals": [ { "Ref": "DockerImageApp" }, "" ] },
+    "BlankDockerImageBuild": { "Fn::Equals": [ { "Ref": "DockerImageBuild" }, "" ] },
+    "BlankDockerImageService": { "Fn::Equals": [ { "Ref": "DockerImageService" }, "" ] },
     "BlankKey": { "Fn::Equals": [ { "Ref": "Key" }, "" ] },
     "BlankRegistryHost": { "Fn::Equals": [ { "Ref": "RegistryHost" }, "" ] },
     "Development": { "Fn::Equals": [ { "Ref": "Development" }, "Yes" ] }
@@ -101,6 +104,21 @@
       "Description": "Development mode",
       "Default": "No",
       "AllowedValues": [ "Yes", "No" ]
+    },
+    "DockerImageApp": {
+      "Type": "String",
+      "Description": "Image to use for the app container. Overrides current Version.",
+      "Default": ""
+    },
+    "DockerImageBuild": {
+      "Type": "String",
+      "Description": "Image to use for the build container. Overrides current Version.",
+      "Default": ""
+    },
+    "DockerImageService": {
+      "Type": "String",
+      "Description": "Image to use for the service container. Overrides current Version.",
+      "Default": ""
     },
     "InstanceCount": {
       "Default": "3",
@@ -801,6 +819,18 @@
               "CLIENT_ID": { "Ref": "ClientId" },
               "CUSTOM_TOPIC": { "Fn::GetAtt": [ "CustomTopic", "Arn" ] },
               "CLUSTER": { "Ref": "Cluster" },
+              "DOCKER_IMAGE_APP": { "Fn::If": [ "BlankDockerImageApp",
+                { "Fn::Join": [ ":", [ "convox/app", { "Ref": "Version" } ] ] },
+                { "Ref": "DockerImageApp" }
+              ] },
+              "DOCKER_IMAGE_BUILD": { "Fn::If": [ "BlankDockerImageBuild",
+                { "Fn::Join": [ ":", [ "convox/build", { "Ref": "Version" } ] ] },
+                { "Ref": "DockerImageBuild" }
+              ] },
+              "DOCKER_IMAGE_SERVICE": { "Fn::If": [ "BlankDockerImageService",
+                { "Fn::Join": [ ":", [ "convox/service", { "Ref": "Version" } ] ] },
+                { "Ref": "DockerImageService" }
+              ] },
               "DYNAMO_BUILDS": { "Ref": "DynamoBuilds" },
               "DYNAMO_RELEASES": { "Ref": "DynamoReleases" },
               "ENCRYPTION_KEY": { "Ref": "EncryptionKey" },

--- a/models/app.go
+++ b/models/app.go
@@ -206,7 +206,7 @@ func (a *App) UpdateParams(changes map[string]string) error {
 }
 
 func (a *App) Formation() (string, error) {
-	data, err := exec.Command("docker", "run", fmt.Sprintf("convox/app:%s", os.Getenv("RELEASE")), "-mode", "staging").Output()
+	data, err := exec.Command("docker", "run", os.Getenv("DOCKER_IMAGE_APP"), "-mode", "staging").Output()
 
 	if err != nil {
 		return "", err

--- a/models/build.go
+++ b/models/build.go
@@ -173,7 +173,7 @@ func (b *Build) ExecuteLocal(r io.Reader, ch chan error) {
 
 	name := b.App
 
-	args := []string{"run", "-i", "--name", fmt.Sprintf("build-%s", b.Id), "-v", "/var/run/docker.sock:/var/run/docker.sock", fmt.Sprintf("convox/build:%s", os.Getenv("RELEASE")), "-id", b.Id, "-push", os.Getenv("REGISTRY_HOST"), "-auth", os.Getenv("PASSWORD"), name, "-"}
+	args := []string{"run", "-i", "--name", fmt.Sprintf("build-%s", b.Id), "-v", "/var/run/docker.sock:/var/run/docker.sock", os.Getenv("DOCKER_IMAGE_BUILD"), "-id", b.Id, "-push", os.Getenv("REGISTRY_HOST"), "-auth", os.Getenv("PASSWORD"), name, "-"}
 
 	err := b.execute(args, r, ch)
 
@@ -192,7 +192,7 @@ func (b *Build) ExecuteRemote(repo string, ch chan error) {
 
 	name := b.App
 
-	args := []string{"run", "--name", fmt.Sprintf("build-%s", b.Id), "-v", "/var/run/docker.sock:/var/run/docker.sock", fmt.Sprintf("convox/build:%s", os.Getenv("RELEASE")), "-id", b.Id, "-push", os.Getenv("REGISTRY_HOST"), "-auth", os.Getenv("PASSWORD"), name}
+	args := []string{"run", "--name", fmt.Sprintf("build-%s", b.Id), "-v", "/var/run/docker.sock:/var/run/docker.sock", os.Getenv("DOCKER_IMAGE_BUILD"), "-id", b.Id, "-push", os.Getenv("REGISTRY_HOST"), "-auth", os.Getenv("PASSWORD"), name}
 
 	parts := strings.Split(repo, "#")
 

--- a/models/release.go
+++ b/models/release.go
@@ -245,7 +245,7 @@ func (r *Release) EnvironmentUrl() string {
 }
 
 func (r *Release) Formation() (string, error) {
-	args := []string{"run", "-i", fmt.Sprintf("convox/app:%s", os.Getenv("RELEASE")), "-mode", "staging"}
+	args := []string{"run", "-i", os.Getenv("DOCKER_IMAGE_APP"), "-mode", "staging"}
 
 	cmd := exec.Command("docker", args...)
 	cmd.Stderr = os.Stderr

--- a/models/service.go
+++ b/models/service.go
@@ -192,7 +192,7 @@ func (s *Service) Create() error {
 }
 
 func (s *Service) Formation() (string, error) {
-	data, err := exec.Command("docker", "run", fmt.Sprintf("convox/service:%s", os.Getenv("RELEASE")), s.Type).Output()
+	data, err := exec.Command("docker", "run", os.Getenv("DOCKER_IMAGE_SERVICE"), s.Type).Output()
 
 	if err != nil {
 		return "", err


### PR DESCRIPTION
The goal of this PR is to allow the kernel to more easily use experimental versions of the app, build, and service containers. We do that by adding parameters and environment variables for each and having `bin/web` pull the containers based on the image name it gets from the variables.

Concretely:

* Adds DockerImageApp, DockerImageBuild, and DockerImageService parameters to the kernel stack.
* Adds DOCKER_IMAGE_APP, DOCKER_IMAGE_BUILD, and DOCKER_IMAGE_SERVICE environment variables to the Kernel Task that default to "convox/<container>:<Version>" unless the above parameters are set. 

Let me know if you'd like to see any additional changes. I've tested this in my staging stack and it looks good from here.