### PR TITLE
send more environment data to rollbar

### DIFF
--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -20,9 +20,10 @@ func Error(log *logger.Logger, err error) {
 		log.Error(err)
 	}
 	extraData := map[string]string{
-		"VPC":     os.Getenv("VPC"),
-		"RELEASE": os.Getenv("RELEASE"),
-		"RACK":    os.Getenv("RACK"),
+		"AWS_REGION": os.Getenv("AWS_REGION"),
+		"RACK":       os.Getenv("RACK"),
+		"RELEASE":    os.Getenv("RELEASE"),
+		"VPC":        os.Getenv("VPC"),
 	}
 	extraField := &rollbar.Field{"env", extraData}
 

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -12,13 +12,21 @@ import (
 
 func init() {
 	rollbar.Token = os.Getenv("ROLLBAR_TOKEN")
+	rollbar.Environment = os.Getenv("CLIENT_ID")
 }
 
 func Error(log *logger.Logger, err error) {
 	if log != nil {
 		log.Error(err)
 	}
-	rollbar.Error(rollbar.ERR, err)
+	extraData := map[string]string{
+		"VPC":     os.Getenv("VPC"),
+		"RELEASE": os.Getenv("RELEASE"),
+		"RACK":    os.Getenv("RACK"),
+	}
+	extraField := &rollbar.Field{"env", extraData}
+
+	rollbar.Error(rollbar.ERR, err, extraField)
 }
 
 func SendMixpanelEvent(event, message string) {


### PR DESCRIPTION
names the rollbar environment after the CLIENT_ID

sends VPC, RELEASE, and RACK under the `env` key.